### PR TITLE
Rename target_groups to static_configs in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ is needed. An example snippet to add to the `scrape_configs` section of your
   - job_name: 'vera'
     scrape_interval: 15s
     metrics_path: /data_request?id=lr_prometheus_metrics
-    target_groups:
+    static_configs:
       - targets: ['192.168.8.68:49451']
 ```
 


### PR DESCRIPTION
target_groups no longer exists.
Removed:
https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#100--2016-07-18
Changed/Deprecated:
https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#0200--2016-06-15
